### PR TITLE
Add additional Laravel scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 Bài tập lớn PHP
 
 !!! Nếu bị lỗi thì thay đổi các đường dẫn từ http://localhost:8080/webbansach/... thành http://localhost:${port}/webbansach/... (với port hiện tại của xampp)
+
+## Laravel Migration
+
+Thư mục `laravel` chứa bộ khung dự án Laravel. Dữ liệu từ project PHP gốc được chuyển dần sang các controller, model và view của Laravel. Bạn cần cài đặt Laravel bằng Composer rồi cấu hình kết nối cơ sở dữ liệu trong file `.env`.
+
+Các route mẫu đã có sẵn:
+
+- `/` trang chủ (`HomeController`)
+- `/chuyen-muc/{id}` hiển thị sản phẩm theo chuyên mục
+- `/san-pham/{id}` chi tiết sản phẩm
+- `/tim-kiem` tìm kiếm sản phẩm
+
+Sao chép nội dung HTML từ các file PHP cũ vào các Blade template tương ứng trong `resources/views` để hoàn tất quá trình chuyển đổi.

--- a/laravel/app/Http/Controllers/CategoryController.php
+++ b/laravel/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ChuyenMuc;
+use App\Models\SanPham;
+
+class CategoryController extends Controller
+{
+    public function show($id)
+    {
+        $chuyenMuc = ChuyenMuc::findOrFail($id);
+        $sanPham = SanPham::where('machuyenmuc', $id)->get();
+
+        return view('category', compact('chuyenMuc', 'sanPham'));
+    }
+}

--- a/laravel/app/Http/Controllers/HomeController.php
+++ b/laravel/app/Http/Controllers/HomeController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+
+class HomeController extends Controller
+{
+    public function index()
+    {
+        $slide = DB::table('sanpham')->where('loaisanpham', 0)->orderByDesc('masanpham')->get();
+        $noibat = DB::table('sanpham')->where('loaisanpham', 2)->orderByDesc('masanpham')->get();
+        $moi = DB::table('sanpham')->where('loaisanpham', 3)->orderByDesc('masanpham')->get();
+        $danhchoban = DB::table('sanpham')->inRandomOrder()->limit(7)->get();
+
+        return view('index', compact('slide', 'noibat', 'moi', 'danhchoban'));
+    }
+}

--- a/laravel/app/Http/Controllers/ProductController.php
+++ b/laravel/app/Http/Controllers/ProductController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SanPham;
+use App\Models\ChuyenMuc;
+
+class ProductController extends Controller
+{
+    public function show($id)
+    {
+        $sanPham = SanPham::findOrFail($id);
+        $chuyenMuc = ChuyenMuc::find($sanPham->machuyenmuc);
+
+        return view('product', compact('sanPham', 'chuyenMuc'));
+    }
+}

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SanPham;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $keyword = $request->query('q');
+        $result = [];
+        if ($keyword) {
+            $result = SanPham::where('tensanpham', 'like', "%{$keyword}%")->get();
+        }
+        return view('search', compact('keyword', 'result'));
+    }
+}

--- a/laravel/app/Models/ChuyenMuc.php
+++ b/laravel/app/Models/ChuyenMuc.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ChuyenMuc extends Model
+{
+    protected $table = 'chuyenmuc';
+    protected $primaryKey = 'machuyenmuc';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/laravel/app/Models/SanPham.php
+++ b/laravel/app/Models/SanPham.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SanPham extends Model
+{
+    protected $table = 'sanpham';
+    protected $primaryKey = 'masanpham';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/laravel/resources/views/category.blade.php
+++ b/laravel/resources/views/category.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>{{ $chuyenMuc->tenchuyenmuc }}</h1>
+    <ul>
+        @foreach($sanPham as $sp)
+            <li><a href="{{ url('/san-pham/' . $sp->masanpham) }}">{{ $sp->tensanpham }}</a></li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/laravel/resources/views/index.blade.php
+++ b/laravel/resources/views/index.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Trang chủ</h1>
+    <h2>Sản phẩm nổi bật</h2>
+    <ul>
+        @foreach($noibat as $sp)
+            <li><a href="{{ url('/san-pham/' . $sp->masanpham) }}">{{ $sp->tensanpham }}</a></li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/laravel/resources/views/layouts/app.blade.php
+++ b/laravel/resources/views/layouts/app.blade.php
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Laravel Migration</title>
+    <link rel="stylesheet" href="/css/app.css">
+</head>
+<body>
+    @yield('content')
+</body>
+</html>

--- a/laravel/resources/views/product.blade.php
+++ b/laravel/resources/views/product.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>{{ $sanPham->tensanpham }}</h1>
+    <p>{{ $sanPham->mota }}</p>
+    <p>{{ number_format($sanPham->giaban) }} VND</p>
+    <p>Chuyên mục: {{ $chuyenMuc->tenchuyenmuc ?? 'N/A' }}</p>
+</div>
+@endsection

--- a/laravel/resources/views/search.blade.php
+++ b/laravel/resources/views/search.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <form method="get" action="{{ url('/tim-kiem') }}">
+        <input type="text" name="q" value="{{ $keyword }}">
+        <button type="submit">Tìm kiếm</button>
+    </form>
+    <ul>
+        @foreach($result as $sp)
+            <li><a href="{{ url('/san-pham/' . $sp->masanpham) }}">{{ $sp->tensanpham }}</a></li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HomeController;
+
+Route::get('/', [HomeController::class, 'index']);
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\SearchController;
+
+Route::get('/chuyen-muc/{id}', [CategoryController::class, 'show']);
+Route::get('/san-pham/{id}', [ProductController::class, 'show']);
+Route::get('/tim-kiem', [SearchController::class, 'index']);


### PR DESCRIPTION
## Summary
- expand Laravel migration with category, product, and search controllers
- define Eloquent models for `sanpham` and `chuyenmuc`
- add Blade views for category, product, search, and update index page
- document the Laravel routes in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68482ae4279c8321850f51e8338dd33a